### PR TITLE
Use app slug instead of app name to infer the app login

### DIFF
--- a/src/main/java/io/quarkus/github/lottery/github/GitHubInstallationRef.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubInstallationRef.java
@@ -3,8 +3,13 @@ package io.quarkus.github.lottery.github;
 /**
  * A reference to a GitHub application installation.
  *
- * @param appName The application name.
+ * @param appSlug The application slug (a cleaned-up version of the app name).
  * @param installationId The installation ID.
  */
-public record GitHubInstallationRef(String appName, long installationId) {
+public record GitHubInstallationRef(String appSlug, long installationId) {
+
+    public String appLogin() {
+        return appSlug() + "[bot]";
+    }
+
 }

--- a/src/main/java/io/quarkus/github/lottery/github/GitHubRepository.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubRepository.java
@@ -66,8 +66,8 @@ public class GitHubRepository implements AutoCloseable {
         return ref;
     }
 
-    public String selfLogin() {
-        return ref.installationRef().appName() + "[bot]";
+    public String appLogin() {
+        return ref.installationRef().appLogin();
     }
 
     private GitHub client() {
@@ -157,9 +157,9 @@ public class GitHubRepository implements AutoCloseable {
     }
 
     private Stream<GHIssueComment> getAppCommentsSince(GHIssue issue, Instant since) {
-        String selfLogin = selfLogin();
+        String appLogin = appLogin();
         return toStream(issue.queryComments().since(Date.from(since)).list())
-                .filter(uncheckedIO((GHIssueComment comment) -> selfLogin.equals(comment.getUser().getLogin()))::apply);
+                .filter(uncheckedIO((GHIssueComment comment) -> appLogin.equals(comment.getUser().getLogin()))::apply);
     }
 
     private void minimizeOutdatedComment(GHIssueComment comment) {

--- a/src/main/java/io/quarkus/github/lottery/github/GitHubService.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubService.java
@@ -28,10 +28,10 @@ public class GitHubService {
         List<GitHubRepositoryRef> result = new ArrayList<>();
         GitHub client = clientProvider.getApplicationClient();
         GHApp app = client.getApp();
-        String appName = app.getName();
+        String appSlug = app.getSlug();
         for (GHAppInstallation installation : app.listInstallations()) {
             long installationId = installation.getId();
-            var installationRef = new GitHubInstallationRef(appName, installationId);
+            var installationRef = new GitHubInstallationRef(appSlug, installationId);
             for (GHRepository repository : clientProvider.getInstallationClient(installationId)
                     .getInstallation().listRepositories()) {
                 result.add(new GitHubRepositoryRef(installationRef, repository.getFullName()));

--- a/src/main/java/io/quarkus/github/lottery/history/HistoryService.java
+++ b/src/main/java/io/quarkus/github/lottery/history/HistoryService.java
@@ -28,7 +28,7 @@ public class HistoryService {
         var persistenceRepo = persistenceRepo(drawRef, config);
         var history = new LotteryHistory(drawRef.instant(), config.buckets());
         String historyTopic = messageFormatter.formatHistoryTopicText(drawRef);
-        persistenceRepo.extractCommentsFromDedicatedIssue(persistenceRepo.selfLogin(), historyTopic, history.since())
+        persistenceRepo.extractCommentsFromDedicatedIssue(persistenceRepo.appLogin(), historyTopic, history.since())
                 .flatMap(uncheckedIO(message -> messageFormatter.extractPayloadFromHistoryBodyMarkdown(message).stream()))
                 .forEach(history::add);
         return history;
@@ -38,7 +38,7 @@ public class HistoryService {
         var persistenceRepo = persistenceRepo(drawRef, config);
         String historyTopic = messageFormatter.formatHistoryTopicText(drawRef);
         String commentBody = messageFormatter.formatHistoryBodyMarkdown(drawRef, reports);
-        persistenceRepo.commentOnDedicatedIssue(persistenceRepo.selfLogin(), historyTopic, commentBody);
+        persistenceRepo.commentOnDedicatedIssue(persistenceRepo.appLogin(), historyTopic, commentBody);
     }
 
     GitHubRepository persistenceRepo(DrawRef drawRef, LotteryConfig config) {

--- a/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
@@ -29,7 +29,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -86,7 +85,7 @@ public class GitHubServiceTest {
                         // Scope: application client
                         var appMock = mocks.ghObject(GHApp.class, 1);
                         when(applicationClient.getApp()).thenReturn(appMock);
-                        when(appMock.getName()).thenReturn(installationRef.appName());
+                        when(appMock.getSlug()).thenReturn(installationRef.appSlug());
 
                         var installationMock = Mockito.mock(GHAppInstallation.class);
                         when(installationMock.getId()).thenReturn(installationRef.installationId());
@@ -251,12 +250,12 @@ public class GitHubServiceTest {
                 .when(() -> {
                     var repo = gitHubService.repository(repoRef);
 
-                    assertThat(repo.extractCommentsFromDedicatedIssue(installationRef.appName() + "[bot]",
+                    assertThat(repo.extractCommentsFromDedicatedIssue(installationRef.appLogin(),
                             "Lottery history for quarkusio/quarkus", since))
                             .isEmpty();
                 })
                 .then().github(mocks -> {
-                    verify(queryIssuesBuilderMock).assignee(installationRef.appName() + "[bot]");
+                    verify(queryIssuesBuilderMock).assignee(installationRef.appLogin());
 
                     verifyNoMoreInteractions(queryIssuesBuilderMock);
                     verifyNoMoreInteractions(mocks.ghObjects());
@@ -297,12 +296,12 @@ public class GitHubServiceTest {
                 .when(() -> {
                     var repo = gitHubService.repository(repoRef);
 
-                    assertThat(repo.extractCommentsFromDedicatedIssue(installationRef.appName() + "[bot]",
+                    assertThat(repo.extractCommentsFromDedicatedIssue(installationRef.appLogin(),
                             "Lottery history for quarkusio/quarkus", since))
                             .isEmpty();
                 })
                 .then().github(mocks -> {
-                    verify(queryIssuesBuilderMock).assignee(installationRef.appName() + "[bot]");
+                    verify(queryIssuesBuilderMock).assignee(installationRef.appLogin());
                     verify(queryCommentsBuilderMock).since(Date.from(since));
 
                     verifyNoMoreInteractions(queryIssuesBuilderMock, queryCommentsBuilderMock);
@@ -337,12 +336,12 @@ public class GitHubServiceTest {
                 .when(() -> {
                     var repo = gitHubService.repository(repoRef);
 
-                    assertThat(repo.extractCommentsFromDedicatedIssue(installationRef.appName() + "[bot]",
+                    assertThat(repo.extractCommentsFromDedicatedIssue(installationRef.appLogin(),
                             "Lottery history for quarkusio/quarkus", since))
                             .isEmpty();
                 })
                 .then().github(mocks -> {
-                    verify(queryIssuesBuilderMock).assignee(installationRef.appName() + "[bot]");
+                    verify(queryIssuesBuilderMock).assignee(installationRef.appLogin());
                     verify(queryCommentsBuilderMock).since(Date.from(since));
 
                     verifyNoMoreInteractions(queryIssuesBuilderMock, queryCommentsBuilderMock);
@@ -371,7 +370,7 @@ public class GitHubServiceTest {
                     when(queryIssuesBuilderMock.list()).thenReturn(issuesMocks);
 
                     var mySelfMock = mocks.ghObject(GHMyself.class, 1L);
-                    when(mySelfMock.getLogin()).thenReturn(installationRef.appName() + "[bot]");
+                    when(mySelfMock.getLogin()).thenReturn(installationRef.appLogin());
                     var someoneElseMock = mocks.ghObject(GHUser.class, 2L);
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
@@ -431,7 +430,7 @@ public class GitHubServiceTest {
                     when(issue2Mock.getState()).thenReturn(GHIssueState.OPEN);
 
                     var mySelfMock = mocks.ghObject(GHMyself.class, 1L);
-                    when(mySelfMock.getLogin()).thenReturn(installationRef.appName() + "[bot]");
+                    when(mySelfMock.getLogin()).thenReturn(installationRef.appLogin());
                     var someoneElseMock = mocks.ghObject(GHUser.class, 2L);
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
@@ -498,7 +497,7 @@ public class GitHubServiceTest {
                     when(issue2Mock.getState()).thenReturn(GHIssueState.CLOSED);
 
                     var mySelfMock = mocks.ghObject(GHMyself.class, 1L);
-                    when(mySelfMock.getLogin()).thenReturn(installationRef.appName() + "[bot]");
+                    when(mySelfMock.getLogin()).thenReturn(installationRef.appLogin());
                     var someoneElseMock = mocks.ghObject(GHUser.class, 2L);
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 

--- a/src/test/java/io/quarkus/github/lottery/HistoryServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/HistoryServiceTest.java
@@ -83,7 +83,7 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String selfUsername = "quarkus-lottery-bot";
-        when(persistenceRepoMock.selfLogin()).thenReturn(selfUsername);
+        when(persistenceRepoMock.appLogin()).thenReturn(selfUsername);
         when(persistenceRepoMock.extractCommentsFromDedicatedIssue(eq(selfUsername), eq(topic), any()))
                 .thenAnswer(ignored -> Stream.of());
 
@@ -111,7 +111,7 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String selfUsername = "quarkus-lottery-bot";
-        when(persistenceRepoMock.selfLogin()).thenReturn(selfUsername);
+        when(persistenceRepoMock.appLogin()).thenReturn(selfUsername);
         String historyBody = "Some content";
         when(persistenceRepoMock.extractCommentsFromDedicatedIssue(eq(selfUsername), eq(topic), any()))
                 .thenAnswer(ignored -> Stream.of(historyBody));
@@ -144,7 +144,7 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String selfUsername = "quarkus-lottery-bot";
-        when(persistenceRepoMock.selfLogin()).thenReturn(selfUsername);
+        when(persistenceRepoMock.appLogin()).thenReturn(selfUsername);
         String historyBody = "Some content";
         when(persistenceRepoMock.extractCommentsFromDedicatedIssue(eq(selfUsername), eq(topic), any()))
                 .thenAnswer(ignored -> Stream.of(historyBody));
@@ -179,7 +179,7 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String selfUsername = "quarkus-lottery-bot";
-        when(persistenceRepoMock.selfLogin()).thenReturn(selfUsername);
+        when(persistenceRepoMock.appLogin()).thenReturn(selfUsername);
         when(persistenceRepoMock.extractCommentsFromDedicatedIssue(eq(selfUsername), eq(topic), any()))
                 .thenAnswer(ignored -> Stream.of());
 
@@ -207,7 +207,7 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String selfUsername = "quarkus-lottery-bot";
-        when(persistenceRepoMock.selfLogin()).thenReturn(selfUsername);
+        when(persistenceRepoMock.appLogin()).thenReturn(selfUsername);
         String historyBody = "Some content";
         when(persistenceRepoMock.extractCommentsFromDedicatedIssue(eq(selfUsername), eq(topic), any()))
                 .thenAnswer(ignored -> Stream.of(historyBody));


### PR DESCRIPTION
This should be more reliable, since the app name may be different from the slug (it may include spaces, uppercase characters, ...).

Requires https://github.com/hub4j/github-api/pull/1525