### PR TITLE
Fix the name of some test methods

### DIFF
--- a/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
@@ -280,7 +280,7 @@ public class GitHubServiceTest {
     }
 
     @Test
-    void issuesLastActedOnByTeamAndLastUpdatedBefore_team() throws IOException {
+    void issuesLastActedOnByAndLastUpdatedBefore_team() throws IOException {
         var repoRef = new GitHubRepositoryRef(installationRef, "quarkusio/quarkus");
 
         Instant now = LocalDateTime.of(2017, 11, 6, 6, 0).toInstant(ZoneOffset.UTC);
@@ -412,7 +412,7 @@ public class GitHubServiceTest {
     }
 
     @Test
-    void issuesLastActedOnByTeamAndLastUpdatedBefore_outsider() throws IOException {
+    void issuesLastActedOnByAndLastUpdatedBefore_outsider() throws IOException {
         var repoRef = new GitHubRepositoryRef(installationRef, "quarkusio/quarkus");
 
         Instant now = LocalDateTime.of(2017, 11, 6, 6, 0).toInstant(ZoneOffset.UTC);

--- a/src/test/java/io/quarkus/github/lottery/HistoryServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/HistoryServiceTest.java
@@ -92,7 +92,7 @@ public class HistoryServiceTest {
     }
 
     @Test
-    void lastNotificationInstantForUser_noHistory() throws Exception {
+    void lastNotificationToday_noHistory() throws Exception {
         var config = defaultConfig();
 
         var persistenceRepoRef = new GitHubRepositoryRef(installationRef,
@@ -117,7 +117,7 @@ public class HistoryServiceTest {
     }
 
     @Test
-    void lastNotificationInstantForUser_notNotified() throws Exception {
+    void lastNotificationToday_notNotified() throws Exception {
         var config = defaultConfig();
 
         var persistenceRepoRef = new GitHubRepositoryRef(installationRef,
@@ -151,7 +151,7 @@ public class HistoryServiceTest {
     }
 
     @Test
-    void lastNotificationInstantForUser_notifiedRecently() throws Exception {
+    void lastNotificationToday_notifiedRecently() throws Exception {
         var config = defaultConfig();
 
         var persistenceRepoRef = new GitHubRepositoryRef(installationRef,


### PR DESCRIPTION
They were using the older name of tested methods that had since been renamed.