### PR TITLE
Fix GitHubService when two history issues exist and one is the prefix of the other

### DIFF
--- a/src/main/java/io/quarkus/github/lottery/github/GitHubDedicatedIssue.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubDedicatedIssue.java
@@ -1,0 +1,4 @@
+package io.quarkus.github.lottery.github;
+
+public class GitHubDedicatedIssue {
+}

--- a/src/main/java/io/quarkus/github/lottery/github/GitHubRepository.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubRepository.java
@@ -302,6 +302,17 @@ public class GitHubRepository implements AutoCloseable {
             builder.assignee(assignee);
         }
         builder.state(GHIssueState.ALL);
+        // Try exact match first to avoid confusion if there are two issues and one is
+        // the exact topic while the other just starts with the topic.
+        // Example:
+        //     topic = Lottery history for quarkusio/quarkus
+        //     issue1.title = Lottery history for quarkusio/quarkusio.github.io
+        //     issue2.title = Lottery history for quarkusio/quarkus
+        for (var issue : builder.list()) {
+            if (issue.getTitle().equals(topic)) {
+                return Optional.of(issue);
+            }
+        }
         for (var issue : builder.list()) {
             if (issue.getTitle().startsWith(topic)) {
                 return Optional.of(issue);


### PR DESCRIPTION
This fixes the most pressing issue, but I'll send another (more complex) PR to also fix the case where the issue we're looking for doesn't exist (so we don't want to fall back to `startsWith`).