### PR TITLE
Fix GitHubService when adding a new history issue and one already exists whose title is the prefix of the new one

### DIFF
--- a/src/main/java/io/quarkus/github/lottery/LotteryService.java
+++ b/src/main/java/io/quarkus/github/lottery/LotteryService.java
@@ -116,7 +116,7 @@ public class LotteryService {
                 continue;
             }
 
-            if (notifier.hasClosedDedicatedIssue(username)) {
+            if (notifier.isIgnoring(username)) {
                 Log.debugf("Skipping user %s whose dedicated issue is closed", username);
                 continue;
             }

--- a/src/main/java/io/quarkus/github/lottery/github/GitHubDedicatedIssue.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubDedicatedIssue.java
@@ -1,4 +1,0 @@
-package io.quarkus.github.lottery.github;
-
-public class GitHubDedicatedIssue {
-}

--- a/src/main/java/io/quarkus/github/lottery/github/TopicRef.java
+++ b/src/main/java/io/quarkus/github/lottery/github/TopicRef.java
@@ -1,0 +1,30 @@
+package io.quarkus.github.lottery.github;
+
+/**
+ * A reference to a {@link GitHubRepository#topic(TopicRef) topic} in a GitHub repository.
+ *
+ * @param assignee The GitHub username of issue assignee.
+ * @param topic The issue's topic, a string that should be prefixed to the title of dedicated issues.
+ * @param expectedSuffixStart If issue titles are suffixed (e.g. with the last update date),
+ *        the (constant) string these suffixes are expected to start with.
+ *        If issue titles are identical to the topic, a {@code null} string.
+ */
+public record TopicRef(String assignee,
+        String topic,
+        String expectedSuffixStart) {
+
+    public TopicRef {
+        if (expectedSuffixStart != null && expectedSuffixStart.isEmpty()) {
+            throw new IllegalArgumentException("expectedSuffixStart must not be empty; pass either null or a non-empty string");
+        }
+    }
+
+    public static TopicRef history(String topic) {
+        return new TopicRef(null, topic, null);
+    }
+
+    public static TopicRef notification(String assignee, String topic) {
+        return new TopicRef(assignee, topic, " (updated");
+    }
+
+}

--- a/src/main/java/io/quarkus/github/lottery/util/Streams.java
+++ b/src/main/java/io/quarkus/github/lottery/util/Streams.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterators;
+import java.util.function.BinaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -63,5 +64,9 @@ public final class Streams {
 
     public static <T> Stream<T> toStream(PagedIterable<T> iterable) {
         return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    public static <T> BinaryOperator<T> last() {
+        return (first, second) -> second;
     }
 }

--- a/src/test/java/io/quarkus/github/lottery/HistoryServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/HistoryServiceTest.java
@@ -23,16 +23,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.quarkus.github.lottery.github.GitHubInstallationRef;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.quarkus.github.lottery.config.LotteryConfig;
 import io.quarkus.github.lottery.draw.DrawRef;
 import io.quarkus.github.lottery.draw.LotteryReport;
+import io.quarkus.github.lottery.github.GitHubInstallationRef;
 import io.quarkus.github.lottery.github.GitHubRepository;
 import io.quarkus.github.lottery.github.GitHubRepositoryRef;
 import io.quarkus.github.lottery.github.GitHubService;
+import io.quarkus.github.lottery.github.TopicRef;
 import io.quarkus.github.lottery.history.HistoryService;
 import io.quarkus.github.lottery.message.MessageFormatter;
 import io.quarkus.test.junit.QuarkusMock;
@@ -66,6 +67,7 @@ public class HistoryServiceTest {
 
     GitHubService gitHubServiceMock;
     GitHubRepository persistenceRepoMock;
+    GitHubRepository.Topic topicMock;
 
     MessageFormatter messageFormatterMock;
 
@@ -85,6 +87,7 @@ public class HistoryServiceTest {
         repoRef = new GitHubRepositoryRef(installationRef, "quarkusio/quarkus");
 
         persistenceRepoMock = Mockito.mock(GitHubRepository.class);
+        topicMock = Mockito.mock(GitHubRepository.Topic.class);
 
         now = LocalDateTime.of(2017, 11, 6, 6, 0).toInstant(ZoneOffset.UTC);
         drawRef = new DrawRef(repoRef, now);
@@ -103,7 +106,9 @@ public class HistoryServiceTest {
 
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
-        when(persistenceRepoMock.extractCommentsFromDedicatedIssue(isNull(), eq(topic), any()))
+        when(persistenceRepoMock.topic(TopicRef.history(topic)))
+                .thenReturn(topicMock);
+        when(topicMock.extractComments(any()))
                 .thenAnswer(ignored -> Stream.of());
 
         var history = historyService.fetch(drawRef, config);
@@ -129,7 +134,9 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String historyBody = "Some content";
-        when(persistenceRepoMock.extractCommentsFromDedicatedIssue(isNull(), eq(topic), any()))
+        when(persistenceRepoMock.topic(TopicRef.history(topic)))
+                .thenReturn(topicMock);
+        when(topicMock.extractComments(any()))
                 .thenAnswer(ignored -> Stream.of(historyBody));
         when(messageFormatterMock.extractPayloadFromHistoryBodyMarkdown(historyBody))
                 .thenReturn(List.of(
@@ -165,7 +172,9 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String historyBody = "Some content";
-        when(persistenceRepoMock.extractCommentsFromDedicatedIssue(isNull(), eq(topic), any()))
+        when(persistenceRepoMock.topic(TopicRef.history(topic)))
+                .thenReturn(topicMock);
+        when(topicMock.extractComments(any()))
                 .thenAnswer(ignored -> Stream.of(historyBody));
         when(messageFormatterMock.extractPayloadFromHistoryBodyMarkdown(historyBody))
                 .thenReturn(List.of(
@@ -207,7 +216,9 @@ public class HistoryServiceTest {
 
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
-        when(persistenceRepoMock.extractCommentsFromDedicatedIssue(isNull(), eq(topic), any()))
+        when(persistenceRepoMock.topic(TopicRef.history(topic)))
+                .thenReturn(topicMock);
+        when(topicMock.extractComments(any()))
                 .thenAnswer(ignored -> Stream.of());
 
         var history = historyService.fetch(drawRef, config);
@@ -229,7 +240,9 @@ public class HistoryServiceTest {
         String topic = "Lottery history for quarkusio/quarkus";
         when(messageFormatterMock.formatHistoryTopicText(drawRef)).thenReturn(topic);
         String historyBody = "Some content";
-        when(persistenceRepoMock.extractCommentsFromDedicatedIssue(isNull(), eq(topic), any()))
+        when(persistenceRepoMock.topic(TopicRef.history(topic)))
+                .thenReturn(topicMock);
+        when(topicMock.extractComments(any()))
                 .thenAnswer(ignored -> Stream.of(historyBody));
         when(messageFormatterMock.extractPayloadFromHistoryBodyMarkdown(historyBody))
                 .thenReturn(List.of(

--- a/src/test/java/io/quarkus/github/lottery/LotterySingleRepositoryTest.java
+++ b/src/test/java/io/quarkus/github/lottery/LotterySingleRepositoryTest.java
@@ -141,7 +141,7 @@ public class LotterySingleRepositoryTest {
 
     private void mockNotifiable(String username, ZoneId timezone) throws IOException {
         when(historyMock.lastNotificationToday(username, timezone)).thenReturn(Optional.empty());
-        when(notifierMock.hasClosedDedicatedIssue(username)).thenReturn(false);
+        when(notifierMock.isIgnoring(username)).thenReturn(false);
     }
 
     @Test
@@ -240,7 +240,7 @@ public class LotterySingleRepositoryTest {
     }
 
     @Test
-    void closedDedicatedIssue() throws IOException {
+    void ignoring() throws IOException {
         var config = defaultConfig(List.of(
                 new LotteryConfig.Participant("yrodiere",
                         Optional.empty(),
@@ -261,7 +261,7 @@ public class LotterySingleRepositoryTest {
         when(repoMock.ref()).thenReturn(repoRef);
 
         when(historyMock.lastNotificationToday("yrodiere", ZoneOffset.UTC)).thenReturn(Optional.empty());
-        when(notifierMock.hasClosedDedicatedIssue("yrodiere")).thenReturn(true);
+        when(notifierMock.isIgnoring("yrodiere")).thenReturn(true);
 
         lotteryService.draw();
 


### PR DESCRIPTION
I had to introduce the notion of `TopicRef` which defines how the topic is recognized, and allows us to make sure we never mistake one topic for another.