### PR TITLE
Use the "search issues" API instead of the "query issues" API

### DIFF
--- a/src/main/java/io/quarkus/github/lottery/config/LotteryConfig.java
+++ b/src/main/java/io/quarkus/github/lottery/config/LotteryConfig.java
@@ -128,8 +128,8 @@ public record LotteryConfig(
                 // TODO default to all labels configured for this user in .github/quarkus-bot.yml
                 @JsonProperty(required = true) List<String> labels,
                 @JsonProperty(required = true) @JsonDeserialize(as = TreeSet.class) Set<DayOfWeek> days,
-                Feedback feedback,
-                @JsonProperty(required = true) Participation stale) {
+                Optional<Feedback> feedback,
+                @JsonProperty Optional<Participation> stale) {
             public record Feedback(
                     @JsonProperty(required = true) Participation needed,
                     @JsonProperty(required = true) Participation provided) {

--- a/src/main/java/io/quarkus/github/lottery/draw/Participant.java
+++ b/src/main/java/io/quarkus/github/lottery/draw/Participant.java
@@ -88,9 +88,12 @@ public final class Participant {
 
     private static final class Maintenance {
         public static Optional<Maintenance> create(String username, LotteryConfig.Participant.Maintenance config) {
-            var feedbackNeeded = Participation.create(username, config.feedback().needed());
-            var feedbackProvided = Participation.create(username, config.feedback().provided());
-            var stale = Participation.create(username, config.stale());
+            var feedbackNeeded = config.feedback().map(LotteryConfig.Participant.Maintenance.Feedback::needed)
+                    .flatMap(p -> Participation.create(username, p));
+            var feedbackProvided = config.feedback().map(LotteryConfig.Participant.Maintenance.Feedback::provided)
+                    .flatMap(p -> Participation.create(username, p));
+            var stale = config.stale()
+                    .flatMap(p -> Participation.create(username, p));
 
             if (feedbackNeeded.isEmpty() && feedbackProvided.isEmpty() && stale.isEmpty()) {
                 return Optional.empty();

--- a/src/main/java/io/quarkus/github/lottery/github/GitHubInstallationRef.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubInstallationRef.java
@@ -1,5 +1,7 @@
 package io.quarkus.github.lottery.github;
 
+import io.quarkus.github.lottery.util.GitHubConstants;
+
 /**
  * A reference to a GitHub application installation.
  *
@@ -9,7 +11,7 @@ package io.quarkus.github.lottery.github;
 public record GitHubInstallationRef(String appSlug, long installationId) {
 
     public String appLogin() {
-        return appSlug() + "[bot]";
+        return appSlug() + GitHubConstants.BOT_LOGIN_SUFFIX;
     }
 
 }

--- a/src/main/java/io/quarkus/github/lottery/github/GitHubSearchClauses.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubSearchClauses.java
@@ -1,0 +1,39 @@
+package io.quarkus.github.lottery.github;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+public final class GitHubSearchClauses {
+
+    private GitHubSearchClauses() {
+    }
+
+    public static String repo(GitHubRepositoryRef ref) {
+        return "repo:" + ref.repositoryName();
+    }
+
+    public static String isIssue() {
+        return "is:issue";
+    }
+
+    public static String anyLabel(Set<String> labels) {
+        return label(String.join(",", labels));
+    }
+
+    public static String label(String label) {
+        return "label:" + label;
+    }
+
+    public static String updatedBefore(Instant updatedBefore) {
+        return "updated:<" + updatedBefore.atOffset(ZoneOffset.UTC).toLocalDateTime().toString();
+    }
+
+    public static String author(String author) {
+        return "author:" + author;
+    }
+
+    public static String assignee(String assignee) {
+        return "assignee:" + assignee;
+    }
+}

--- a/src/main/java/io/quarkus/github/lottery/util/GitHubConstants.java
+++ b/src/main/java/io/quarkus/github/lottery/util/GitHubConstants.java
@@ -1,0 +1,10 @@
+package io.quarkus.github.lottery.util;
+
+public final class GitHubConstants {
+
+    private GitHubConstants() {
+    }
+
+    public static final String BOT_LOGIN_SUFFIX = "[bot]";
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,7 @@ quarkus.info.enabled=true
 %dev.quarkus.scheduler.enabled=false
 %dev.quarkus.log.min-level=TRACE
 %dev.quarkus.log.category."io.quarkus.github.lottery".level=TRACE
+%dev.quarkus.log.category."org.kohsuke.github.GitHubClient".level=TRACE
 
 %prod.quarkus.openshift.labels."app"=quarkus-github-lottery
 # Renew the SSL certificate automatically

--- a/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
@@ -200,6 +200,15 @@ public class GitHubServiceTest {
                                         stewardship:
                                           days: ["MONDAY"]
                                           maxIssues: 10
+                                      - username: "jblack"
+                                        maintenance:
+                                          labels: ["area/someotherobscurelibrary"]
+                                          days: ["MONDAY"]
+                                          feedback:
+                                            needed:
+                                              maxIssues: 1
+                                            provided:
+                                              maxIssues: 1
                                     """);
                 })
                 .when(() -> {
@@ -235,10 +244,10 @@ public class GitHubServiceTest {
                                                     Optional.of(new LotteryConfig.Participant.Maintenance(
                                                             List.of("area/hibernate-orm", "area/hibernate-search"),
                                                             Set.of(DayOfWeek.MONDAY),
-                                                            new LotteryConfig.Participant.Maintenance.Feedback(
+                                                            Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                                                     new LotteryConfig.Participant.Participation(4),
-                                                                    new LotteryConfig.Participant.Participation(2)),
-                                                            new LotteryConfig.Participant.Participation(5))),
+                                                                    new LotteryConfig.Participant.Participation(2))),
+                                                            Optional.of(new LotteryConfig.Participant.Participation(5)))),
                                                     Optional.empty()),
                                             new LotteryConfig.Participant("gsmet",
                                                     Optional.of(ZoneId.of("Europe/Paris")),
@@ -253,10 +262,10 @@ public class GitHubServiceTest {
                                                     Optional.of(new LotteryConfig.Participant.Maintenance(
                                                             List.of("area/someobscurelibrary"),
                                                             Set.of(DayOfWeek.MONDAY),
-                                                            new LotteryConfig.Participant.Maintenance.Feedback(
+                                                            Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                                                     new LotteryConfig.Participant.Participation(1),
-                                                                    new LotteryConfig.Participant.Participation(1)),
-                                                            new LotteryConfig.Participant.Participation(5))),
+                                                                    new LotteryConfig.Participant.Participation(1))),
+                                                            Optional.of(new LotteryConfig.Participant.Participation(5)))),
                                                     Optional.empty()),
                                             new LotteryConfig.Participant("geoand",
                                                     Optional.empty(),
@@ -264,7 +273,18 @@ public class GitHubServiceTest {
                                                     Optional.empty(),
                                                     Optional.of(new LotteryConfig.Participant.Stewardship(
                                                             Set.of(DayOfWeek.MONDAY),
-                                                            new LotteryConfig.Participant.Participation(10)))))));
+                                                            new LotteryConfig.Participant.Participation(10)))),
+                                            new LotteryConfig.Participant("jblack",
+                                                    Optional.empty(),
+                                                    Optional.empty(),
+                                                    Optional.of(new LotteryConfig.Participant.Maintenance(
+                                                            List.of("area/someotherobscurelibrary"),
+                                                            Set.of(DayOfWeek.MONDAY),
+                                                            Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
+                                                                    new LotteryConfig.Participant.Participation(1),
+                                                                    new LotteryConfig.Participant.Participation(1))),
+                                                            Optional.empty())),
+                                                    Optional.empty()))));
                 })
                 .then().github(mocks -> {
                     verifyNoMoreInteractions(mocks.ghObjects());

--- a/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
@@ -780,11 +780,8 @@ public class GitHubServiceTest {
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
                     when(issue2Mock.queryComments()).thenReturn(queryCommentsBuilderMock);
-                    var issue2Comment1Mock = mocks.issueComment(201);
-                    when(issue2Comment1Mock.getUser()).thenReturn(someoneElseMock);
-                    var issue2Comment2Mock = mocks.issueComment(202);
-                    when(issue2Comment2Mock.getUser()).thenReturn(someoneElseMock);
-                    var issue2CommentMocks = mockPagedIterable(issue2Comment1Mock, issue2Comment2Mock);
+                    var issue2CommentMocks = mockPagedIterable(mockIssueComment(mocks, 201, someoneElseMock),
+                            mockIssueComment(mocks, 202, someoneElseMock));
                     when(queryCommentsBuilderMock.list()).thenReturn(issue2CommentMocks);
                 })
                 .when(() -> {
@@ -871,15 +868,10 @@ public class GitHubServiceTest {
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
                     when(issue2Mock.queryComments()).thenReturn(queryCommentsBuilderMock);
-                    var issue2Comment1Mock = mocks.issueComment(202);
-                    when(issue2Comment1Mock.getUser()).thenReturn(mySelfMock);
-                    when(issue2Comment1Mock.getBody()).thenReturn("issue2Comment1Mock#body");
-                    var issue2Comment2Mock = mocks.issueComment(203);
-                    when(issue2Comment2Mock.getUser()).thenReturn(mySelfMock);
-                    when(issue2Comment2Mock.getBody()).thenReturn("issue2Comment2Mock#body");
-                    var issue2Comment3Mock = mocks.issueComment(204);
-                    when(issue2Comment3Mock.getUser()).thenReturn(someoneElseMock);
-                    var issue2CommentMocks = mockPagedIterable(issue2Comment1Mock, issue2Comment2Mock, issue2Comment3Mock);
+                    var issue2CommentMocks = mockPagedIterable(
+                            mockIssueComment(mocks, 201, mySelfMock, "issue2Comment1Mock#body"),
+                            mockIssueComment(mocks, 202, mySelfMock, "issue2Comment2Mock#body"),
+                            mockIssueComment(mocks, 203, someoneElseMock));
                     when(queryCommentsBuilderMock.list()).thenReturn(issue2CommentMocks);
                 })
                 .when(() -> {
@@ -925,14 +917,9 @@ public class GitHubServiceTest {
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
                     when(issue2Mock.queryComments()).thenReturn(queryCommentsBuilderMock);
-                    var issue2Comment1Mock = mocks.issueComment(202);
-                    when(issue2Comment1Mock.getUser()).thenReturn(mySelfMock);
-                    when(issue2Comment1Mock.getBody()).thenReturn("issue2Comment1Mock#body");
-                    var issue2Comment2Mock = mocks.issueComment(203);
-                    when(issue2Comment2Mock.getUser()).thenReturn(mySelfMock);
-                    when(issue2Comment2Mock.getBody()).thenReturn("issue2Comment2Mock#body");
-                    var issue2Comment3Mock = mocks.issueComment(204);
-                    when(issue2Comment3Mock.getUser()).thenReturn(someoneElseMock);
+                    var issue2Comment1Mock = mockIssueComment(mocks, 202, mySelfMock, "issue2Comment1Mock#body");
+                    var issue2Comment2Mock = mockIssueComment(mocks, 203, mySelfMock, "issue2Comment2Mock#body");
+                    var issue2Comment3Mock = mockIssueComment(mocks, 204, someoneElseMock);
                     var issue2CommentMocks = mockPagedIterable(issue2Comment1Mock, issue2Comment2Mock, issue2Comment3Mock);
                     when(queryCommentsBuilderMock.list()).thenReturn(issue2CommentMocks);
                 })
@@ -987,16 +974,12 @@ public class GitHubServiceTest {
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
                     when(issue2Mock.queryComments()).thenReturn(queryCommentsBuilderMock);
-                    var issue2Comment1Mock = mocks.issueComment(201);
-                    when(issue2Comment1Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment2Mock = mocks.issueComment(202);
-                    when(issue2Comment2Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment3Mock = mocks.issueComment(203);
-                    when(issue2Comment3Mock.getUser()).thenReturn(someoneElseMock);
-                    var issue2CommentMocks = mockPagedIterable(issue2Comment1Mock, issue2Comment2Mock, issue2Comment3Mock);
+                    var commentToMinimizeMock = mockIssueComment(mocks, 202, mySelfMock);
+                    when(commentToMinimizeMock.getNodeId()).thenReturn(commentToMinimizeNodeId);
+                    var issue2CommentMocks = mockPagedIterable(mockIssueComment(mocks, 201, mySelfMock),
+                            commentToMinimizeMock,
+                            mockIssueComment(mocks, 203, someoneElseMock));
                     when(queryCommentsBuilderMock.list()).thenReturn(issue2CommentMocks);
-
-                    when(issue2Comment2Mock.getNodeId()).thenReturn(commentToMinimizeNodeId);
 
                     when(messageFormatterMock.formatDedicatedIssueBodyMarkdown("yrodiere's report for quarkusio/quarkus",
                             "Some content"))
@@ -1062,16 +1045,12 @@ public class GitHubServiceTest {
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
                     when(issue2Mock.queryComments()).thenReturn(queryCommentsBuilderMock);
-                    var issue2Comment1Mock = mocks.issueComment(201);
-                    when(issue2Comment1Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment2Mock = mocks.issueComment(202);
-                    when(issue2Comment2Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment3Mock = mocks.issueComment(203);
-                    when(issue2Comment3Mock.getUser()).thenReturn(someoneElseMock);
-                    var issue2CommentMocks = mockPagedIterable(issue2Comment1Mock, issue2Comment2Mock, issue2Comment3Mock);
+                    var commentToMinimizeMock = mockIssueComment(mocks, 202, mySelfMock);
+                    when(commentToMinimizeMock.getNodeId()).thenReturn(commentToMinimizeNodeId);
+                    var issue2CommentMocks = mockPagedIterable(mockIssueComment(mocks, 201, mySelfMock),
+                            mockIssueComment(mocks, 202, mySelfMock),
+                            mockIssueComment(mocks, 203, someoneElseMock));
                     when(queryCommentsBuilderMock.list()).thenReturn(issue2CommentMocks);
-
-                    when(issue2Comment2Mock.getNodeId()).thenReturn(commentToMinimizeNodeId);
 
                     when(messageFormatterMock.formatDedicatedIssueBodyMarkdown("Lottery history for quarkusio/quarkus",
                             "Some content"))
@@ -1135,16 +1114,12 @@ public class GitHubServiceTest {
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
                     when(issue2Mock.queryComments()).thenReturn(queryCommentsBuilderMock);
-                    var issue2Comment1Mock = mocks.issueComment(201);
-                    when(issue2Comment1Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment2Mock = mocks.issueComment(202);
-                    when(issue2Comment2Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment3Mock = mocks.issueComment(203);
-                    when(issue2Comment3Mock.getUser()).thenReturn(someoneElseMock);
-                    var issue2CommentMocks = mockPagedIterable(issue2Comment1Mock, issue2Comment2Mock, issue2Comment3Mock);
+                    var commentToMinimizeMock = mockIssueComment(mocks, 202, mySelfMock);
+                    when(commentToMinimizeMock.getNodeId()).thenReturn(commentToMinimizeNodeId);
+                    var issue2CommentMocks = mockPagedIterable(mockIssueComment(mocks, 201, mySelfMock),
+                            mockIssueComment(mocks, 202, mySelfMock),
+                            mockIssueComment(mocks, 203, someoneElseMock));
                     when(queryCommentsBuilderMock.list()).thenReturn(issue2CommentMocks);
-
-                    when(issue2Comment2Mock.getNodeId()).thenReturn(commentToMinimizeNodeId);
 
                     when(messageFormatterMock.formatDedicatedIssueBodyMarkdown("Lottery history for quarkusio/quarkus",
                             "Some content"))
@@ -1209,16 +1184,12 @@ public class GitHubServiceTest {
                     when(someoneElseMock.getLogin()).thenReturn("yrodiere");
 
                     when(issue2Mock.queryComments()).thenReturn(queryCommentsBuilderMock);
-                    var issue2Comment1Mock = mocks.issueComment(201);
-                    when(issue2Comment1Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment2Mock = mocks.issueComment(202);
-                    when(issue2Comment2Mock.getUser()).thenReturn(mySelfMock);
-                    var issue2Comment3Mock = mocks.issueComment(203);
-                    when(issue2Comment3Mock.getUser()).thenReturn(someoneElseMock);
-                    var issue2CommentMocks = mockPagedIterable(issue2Comment1Mock, issue2Comment2Mock, issue2Comment3Mock);
+                    var commentToMinimizeMock = mockIssueComment(mocks, 202, mySelfMock);
+                    when(commentToMinimizeMock.getNodeId()).thenReturn(commentToMinimizeNodeId);
+                    var issue2CommentMocks = mockPagedIterable(mockIssueComment(mocks, 201, mySelfMock),
+                            mockIssueComment(mocks, 202, mySelfMock),
+                            mockIssueComment(mocks, 203, someoneElseMock));
                     when(queryCommentsBuilderMock.list()).thenReturn(issue2CommentMocks);
-
-                    when(issue2Comment2Mock.getNodeId()).thenReturn(commentToMinimizeNodeId);
 
                     when(messageFormatterMock.formatDedicatedIssueBodyMarkdown("yrodiere's report for quarkusio/quarkus",
                             "Some content"))

--- a/src/test/java/io/quarkus/github/lottery/LotterySingleRepositoryTest.java
+++ b/src/test/java/io/quarkus/github/lottery/LotterySingleRepositoryTest.java
@@ -155,10 +155,10 @@ public class LotterySingleRepositoryTest {
                         Optional.of(new LotteryConfig.Participant.Maintenance(
                                 List.of("area/hibernate-orm", "area/hibernate-search"),
                                 Set.of(DayOfWeek.TUESDAY),
-                                new LotteryConfig.Participant.Maintenance.Feedback(
+                                Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                         new LotteryConfig.Participant.Participation(4),
-                                        new LotteryConfig.Participant.Participation(2)),
-                                new LotteryConfig.Participant.Participation(5))),
+                                        new LotteryConfig.Participant.Participation(2))),
+                                Optional.of(new LotteryConfig.Participant.Participation(5)))),
                         Optional.of(new LotteryConfig.Participant.Stewardship(
                                 Set.of(DayOfWeek.TUESDAY),
                                 new LotteryConfig.Participant.Participation(10))))));
@@ -185,10 +185,10 @@ public class LotterySingleRepositoryTest {
                         Optional.of(new LotteryConfig.Participant.Maintenance(
                                 List.of("area/hibernate-orm", "area/hibernate-search"),
                                 Set.of(DayOfWeek.MONDAY),
-                                new LotteryConfig.Participant.Maintenance.Feedback(
+                                Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                         new LotteryConfig.Participant.Participation(4),
-                                        new LotteryConfig.Participant.Participation(2)),
-                                new LotteryConfig.Participant.Participation(5))),
+                                        new LotteryConfig.Participant.Participation(2))),
+                                Optional.of(new LotteryConfig.Participant.Participation(5)))),
                         Optional.of(new LotteryConfig.Participant.Stewardship(
                                 Set.of(DayOfWeek.TUESDAY),
                                 new LotteryConfig.Participant.Participation(10))))));
@@ -217,10 +217,10 @@ public class LotterySingleRepositoryTest {
                         Optional.of(new LotteryConfig.Participant.Maintenance(
                                 List.of("area/hibernate-orm", "area/hibernate-search"),
                                 Set.of(DayOfWeek.MONDAY),
-                                new LotteryConfig.Participant.Maintenance.Feedback(
+                                Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                         new LotteryConfig.Participant.Participation(4),
-                                        new LotteryConfig.Participant.Participation(2)),
-                                new LotteryConfig.Participant.Participation(5))),
+                                        new LotteryConfig.Participant.Participation(2))),
+                                Optional.of(new LotteryConfig.Participant.Participation(5)))),
                         Optional.of(new LotteryConfig.Participant.Stewardship(
                                 Set.of(DayOfWeek.TUESDAY),
                                 new LotteryConfig.Participant.Participation(10))))));
@@ -250,10 +250,10 @@ public class LotterySingleRepositoryTest {
                         Optional.of(new LotteryConfig.Participant.Maintenance(
                                 List.of("area/hibernate-orm", "area/hibernate-search"),
                                 Set.of(DayOfWeek.MONDAY),
-                                new LotteryConfig.Participant.Maintenance.Feedback(
+                                Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                         new LotteryConfig.Participant.Participation(4),
-                                        new LotteryConfig.Participant.Participation(2)),
-                                new LotteryConfig.Participant.Participation(5))),
+                                        new LotteryConfig.Participant.Participation(2))),
+                                Optional.of(new LotteryConfig.Participant.Participation(5)))),
                         Optional.of(new LotteryConfig.Participant.Stewardship(
                                 Set.of(DayOfWeek.TUESDAY),
                                 new LotteryConfig.Participant.Participation(10))))));
@@ -366,10 +366,10 @@ public class LotterySingleRepositoryTest {
                         Optional.of(new LotteryConfig.Participant.Maintenance(
                                 List.of("area/hibernate-orm", "area/hibernate-search"),
                                 Set.of(DayOfWeek.MONDAY),
-                                new LotteryConfig.Participant.Maintenance.Feedback(
+                                Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                         new LotteryConfig.Participant.Participation(4),
-                                        new LotteryConfig.Participant.Participation(2)),
-                                new LotteryConfig.Participant.Participation(5))),
+                                        new LotteryConfig.Participant.Participation(2))),
+                                Optional.of(new LotteryConfig.Participant.Participation(5)))),
                         Optional.empty())));
         when(repoMock.fetchLotteryConfig()).thenReturn(Optional.of(config));
 
@@ -440,10 +440,10 @@ public class LotterySingleRepositoryTest {
                         Optional.of(new LotteryConfig.Participant.Maintenance(
                                 List.of("area/hibernate-orm", "area/hibernate-search"),
                                 Set.of(DayOfWeek.MONDAY),
-                                new LotteryConfig.Participant.Maintenance.Feedback(
+                                Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                         new LotteryConfig.Participant.Participation(4),
-                                        new LotteryConfig.Participant.Participation(2)),
-                                new LotteryConfig.Participant.Participation(5))),
+                                        new LotteryConfig.Participant.Participation(2))),
+                                Optional.of(new LotteryConfig.Participant.Participation(5)))),
                         Optional.empty())));
         when(repoMock.fetchLotteryConfig()).thenReturn(Optional.of(config));
 
@@ -604,10 +604,10 @@ public class LotterySingleRepositoryTest {
                         Optional.of(new LotteryConfig.Participant.Maintenance(
                                 List.of("area/hibernate-search"),
                                 Set.of(DayOfWeek.MONDAY),
-                                new LotteryConfig.Participant.Maintenance.Feedback(
+                                Optional.of(new LotteryConfig.Participant.Maintenance.Feedback(
                                         new LotteryConfig.Participant.Participation(4),
-                                        new LotteryConfig.Participant.Participation(2)),
-                                new LotteryConfig.Participant.Participation(5))),
+                                        new LotteryConfig.Participant.Participation(2))),
+                                Optional.of(new LotteryConfig.Participant.Participation(5)))),
                         Optional.empty()),
                 new LotteryConfig.Participant("gsmet",
                         Optional.empty(),

--- a/src/test/java/io/quarkus/github/lottery/util/MockHelper.java
+++ b/src/test/java/io/quarkus/github/lottery/util/MockHelper.java
@@ -76,6 +76,18 @@ public class MockHelper {
         return mock;
     }
 
+    public static GHIssue mockIssueForLottery(GitHubMockContext context, int number, Date updatedAt, GHUser reporter)
+            throws IOException {
+        GHIssue mock = context.issue(10000L + number);
+        when(mock.isPullRequest()).thenReturn(false);
+        when(mock.getNumber()).thenReturn(number);
+        when(mock.getTitle()).thenReturn("Title for issue " + number);
+        when(mock.getHtmlUrl()).thenReturn(url(number));
+        when(mock.getUpdatedAt()).thenReturn(updatedAt);
+        when(mock.getUser()).thenReturn(reporter);
+        return mock;
+    }
+
     public static GHIssue mockIssueForLotteryFilteredOutByRepository(GitHubMockContext context, int number, Date updatedAt)
             throws IOException {
         GHIssue mock = context.issue(10000L + number);
@@ -87,6 +99,16 @@ public class MockHelper {
     public static GHPullRequest mockPullRequestForLotteryFilteredOutByRepository(GitHubMockContext context, int number) {
         GHPullRequest mock = context.pullRequest(10000L + number);
         when(mock.isPullRequest()).thenReturn(true);
+        return mock;
+    }
+
+    public static GHIssue mockIssueForLotteryFilteredOutByRepository(GitHubMockContext context, int number, Date updatedAt,
+            GHUser reporter)
+            throws IOException {
+        GHIssue mock = context.issue(10000L + number);
+        when(mock.isPullRequest()).thenReturn(false);
+        when(mock.getUpdatedAt()).thenReturn(updatedAt);
+        when(mock.getUser()).thenReturn(reporter);
         return mock;
     }
 

--- a/src/test/java/io/quarkus/github/lottery/util/MockHelper.java
+++ b/src/test/java/io/quarkus/github/lottery/util/MockHelper.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.withSettings;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -18,7 +17,6 @@ import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHIssueEvent;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHPermissionType;
-import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestFileDetail;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
@@ -65,49 +63,35 @@ public class MockHelper {
         return new Issue(number, "Title for issue " + number, url(number));
     }
 
-    public static GHIssue mockIssueForLottery(GitHubMockContext context, int number, Date updatedAt)
+    public static GHIssue mockIssueForLottery(GitHubMockContext context, int number)
             throws IOException {
         GHIssue mock = context.issue(10000L + number);
-        when(mock.isPullRequest()).thenReturn(false);
         when(mock.getNumber()).thenReturn(number);
         when(mock.getTitle()).thenReturn("Title for issue " + number);
         when(mock.getHtmlUrl()).thenReturn(url(number));
-        when(mock.getUpdatedAt()).thenReturn(updatedAt);
         return mock;
     }
 
-    public static GHIssue mockIssueForLottery(GitHubMockContext context, int number, Date updatedAt, GHUser reporter)
+    public static GHIssue mockIssueForLottery(GitHubMockContext context, int number, GHUser reporter)
             throws IOException {
         GHIssue mock = context.issue(10000L + number);
-        when(mock.isPullRequest()).thenReturn(false);
         when(mock.getNumber()).thenReturn(number);
         when(mock.getTitle()).thenReturn("Title for issue " + number);
         when(mock.getHtmlUrl()).thenReturn(url(number));
-        when(mock.getUpdatedAt()).thenReturn(updatedAt);
         when(mock.getUser()).thenReturn(reporter);
         return mock;
     }
 
-    public static GHIssue mockIssueForLotteryFilteredOutByRepository(GitHubMockContext context, int number, Date updatedAt)
+    public static GHIssue mockIssueForLotteryFilteredOutByRepository(GitHubMockContext context, int number)
             throws IOException {
         GHIssue mock = context.issue(10000L + number);
-        when(mock.isPullRequest()).thenReturn(false);
-        when(mock.getUpdatedAt()).thenReturn(updatedAt);
         return mock;
     }
 
-    public static GHPullRequest mockPullRequestForLotteryFilteredOutByRepository(GitHubMockContext context, int number) {
-        GHPullRequest mock = context.pullRequest(10000L + number);
-        when(mock.isPullRequest()).thenReturn(true);
-        return mock;
-    }
-
-    public static GHIssue mockIssueForLotteryFilteredOutByRepository(GitHubMockContext context, int number, Date updatedAt,
+    public static GHIssue mockIssueForLotteryFilteredOutByRepository(GitHubMockContext context, int number,
             GHUser reporter)
             throws IOException {
         GHIssue mock = context.issue(10000L + number);
-        when(mock.isPullRequest()).thenReturn(false);
-        when(mock.getUpdatedAt()).thenReturn(updatedAt);
         when(mock.getUser()).thenReturn(reporter);
         return mock;
     }

--- a/src/test/java/io/quarkus/github/lottery/util/MockHelper.java
+++ b/src/test/java/io/quarkus/github/lottery/util/MockHelper.java
@@ -13,18 +13,23 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import io.quarkiverse.githubapp.testing.dsl.GitHubMockContext;
-import io.quarkus.github.lottery.github.Issue;
 import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHIssueEvent;
 import org.kohsuke.github.GHLabel;
+import org.kohsuke.github.GHPermissionType;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestFileDetail;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
 import org.kohsuke.github.PagedIterator;
 import org.kohsuke.github.PagedSearchIterable;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 import org.mockito.quality.Strictness;
+
+import io.quarkiverse.githubapp.testing.dsl.GitHubMockContext;
+import io.quarkus.github.lottery.github.Issue;
 
 public class MockHelper {
 
@@ -106,6 +111,38 @@ public class MockHelper {
     public static GHPullRequestFileDetail mockGHPullRequestFileDetail(String filename) {
         GHPullRequestFileDetail mock = mock(GHPullRequestFileDetail.class);
         lenient().when(mock.getFilename()).thenReturn(filename);
+        return mock;
+    }
+
+    public static GHUser mockUserForInspectedComments(GitHubMockContext context, GHRepository repositoryMock,
+            long id, String login)
+            throws IOException {
+        return mockUserForInspectedComments(context, repositoryMock, id, login, null);
+    }
+
+    public static GHUser mockUserForInspectedComments(GitHubMockContext context, GHRepository repositoryMock,
+            long id, String login, GHPermissionType permissionType)
+            throws IOException {
+        GHUser mock = context.ghObject(GHUser.class, id);
+        when(mock.getLogin()).thenReturn(login);
+        if (permissionType != null) {
+            when(repositoryMock.getPermission(mock)).thenReturn(permissionType);
+        }
+        return mock;
+    }
+
+    public static GHIssueComment mockIssueComment(GitHubMockContext context, long id, GHUser author)
+            throws IOException {
+        return mockIssueComment(context, id, author, null);
+    }
+
+    public static GHIssueComment mockIssueComment(GitHubMockContext context, long id, GHUser author, String body)
+            throws IOException {
+        GHIssueComment mock = context.issueComment(id);
+        when(mock.getUser()).thenReturn(author);
+        if (body != null) {
+            when(mock.getBody()).thenReturn(body);
+        }
         return mock;
     }
 


### PR DESCRIPTION
... and various other improvements.

Fixes #182.

This paves the way towards #32, which -- in order to be implemented efficiently -- will likely require that we be able to use `-commenter:somemaintainer` filters (otherwise we'd be going through comments of *lots* of issues).