### PR TITLE
Exclude issues with linked PRs from created bucket

### DIFF
--- a/src/main/java/io/quarkus/github/lottery/github/GitHubRepository.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubRepository.java
@@ -7,6 +7,7 @@ import static io.quarkus.github.lottery.github.GitHubSearchClauses.commenter;
 import static io.quarkus.github.lottery.github.GitHubSearchClauses.created;
 import static io.quarkus.github.lottery.github.GitHubSearchClauses.isIssue;
 import static io.quarkus.github.lottery.github.GitHubSearchClauses.label;
+import static io.quarkus.github.lottery.github.GitHubSearchClauses.noLinkedPr;
 import static io.quarkus.github.lottery.github.GitHubSearchClauses.not;
 import static io.quarkus.github.lottery.github.GitHubSearchClauses.repo;
 import static io.quarkus.github.lottery.github.GitHubSearchClauses.updated;
@@ -232,6 +233,7 @@ public class GitHubRepository implements AutoCloseable {
                 .isOpen()
                 .q(label(filterLabel))
                 .q(not(anyLabel(ignoreLabels)))
+                .q(noLinkedPr())
                 .q(created(createdAfter, createdBefore))
                 .sort(GHIssueSearchBuilder.Sort.CREATED)
                 .order(GHDirection.ASC);

--- a/src/main/java/io/quarkus/github/lottery/github/GitHubSearchClauses.java
+++ b/src/main/java/io/quarkus/github/lottery/github/GitHubSearchClauses.java
@@ -19,6 +19,10 @@ public final class GitHubSearchClauses {
         return "-" + clause;
     }
 
+    public static String noLinkedPr() {
+        return "-linked:pr";
+    }
+
     public static <T> String range(String field, T min, T max, Function<T, String> renderer) {
         if (min == null && max == null) {
             return " ";

--- a/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
+++ b/src/test/java/io/quarkus/github/lottery/GitHubServiceTest.java
@@ -1037,6 +1037,7 @@ public class GitHubServiceTest {
                     verify(searchIssuesBuilderMock).q("label:area/hibernate-search");
                     verify(searchIssuesBuilderMock).q("created:2017-10-23T06:00..2017-11-06T06:00");
                     verify(searchIssuesBuilderMock).q("-label:triage/needs-feedback,triage/needs-reproducer,triage/on-ice");
+                    verify(searchIssuesBuilderMock).q("-linked:pr");
                     verify(searchIssuesBuilderMock).q("-commenter:yrodiere");
                     verifyNoMoreInteractions(searchIssuesBuilderMock);
 


### PR DESCRIPTION
Issues that already have linked pull requests don't need maintainer triage, as someone is already working on them. This change adds the -linked:pr filter to the GitHub search query for newly created issues.

Fixes #218

Assisted-By: Claude Code <noreply@anthropic.com>